### PR TITLE
Fix performance issue with CaseSensitivity enabled

### DIFF
--- a/Jace.Benchmark/BenchMarkOperation.cs
+++ b/Jace.Benchmark/BenchMarkOperation.cs
@@ -10,6 +10,7 @@ namespace Jace.Benchmark
     {
         public string Formula { get; set; }
         public BenchmarkMode Mode { get; set; }
-        public Func<CalculationEngine, string, TimeSpan>  BenchMarkDelegate { get; set; }
+        public Func<CalculationEngine, string, Dictionary<string, double>, TimeSpan>  BenchMarkDelegate { get; set; }
+        public Dictionary<string, double> VariableDict { get; set; }
     }
 }

--- a/Jace.Benchmark/Program.cs
+++ b/Jace.Benchmark/Program.cs
@@ -39,6 +39,8 @@ namespace Jace.Benchmark
 
             BenchMarkOperation[] benchmarks = {
                 new BenchMarkOperation() { Formula = "2+3*7", Mode = BenchmarkMode.Static, BenchMarkDelegate = BenchMarkCalculationEngine },
+                new BenchMarkOperation() { Formula = "something2 - (var1 + var2 * 3)/(2+3)", Mode = BenchmarkMode.Simple, BenchMarkDelegate = BenchMarkCalculationEngine, 
+                        VariableDict = new Dictionary<string, double>(){{"var1", 4.5642}, {"var2", 845.4235}, { "something2", 25038.66 } } },
                 new BenchMarkOperation() { Formula = "logn(var1, (2+3) * 500)", Mode = BenchmarkMode.SimpleFunction , BenchMarkDelegate = BenchMarkCalculationEngineFunctionBuild },
                 new BenchMarkOperation() { Formula = "(var1 + var2 * 3)/(2+3) - something", Mode = BenchmarkMode.Simple , BenchMarkDelegate = BenchMarkCalculationEngineFunctionBuild },
             };
@@ -57,25 +59,25 @@ namespace Jace.Benchmark
                 {
                     if (caseSensitivity == CaseSensitivity.All || caseSensitivity == CaseSensitivity.CaseInSensitive)
                     {
-                        duration = benchmark.BenchMarkDelegate(interpretedEngine, benchmark.Formula);
+                        duration = benchmark.BenchMarkDelegate(interpretedEngine, benchmark.Formula, benchmark.VariableDict);
                         table.AddBenchmarkRecord("Interpreted", false, benchmark.Formula, null, NumberOfTests, duration);
                     }
 
                     if (caseSensitivity == CaseSensitivity.All || caseSensitivity == CaseSensitivity.CaseSensitive)
                     {
-                        duration = benchmark.BenchMarkDelegate(interpretedEngineCaseSensitive, benchmark.Formula);
+                        duration = benchmark.BenchMarkDelegate(interpretedEngineCaseSensitive, benchmark.Formula, benchmark.VariableDict);
                         table.AddBenchmarkRecord("Interpreted", true, benchmark.Formula, null, NumberOfTests, duration);
                     }
 
                     if (caseSensitivity == CaseSensitivity.All || caseSensitivity == CaseSensitivity.CaseInSensitive)
                     {
-                        duration = benchmark.BenchMarkDelegate(compiledEngine, benchmark.Formula);
+                        duration = benchmark.BenchMarkDelegate(compiledEngine, benchmark.Formula, benchmark.VariableDict);
                         table.AddBenchmarkRecord("Compiled", false, benchmark.Formula, null, NumberOfTests, duration);
                     }
 
                     if (caseSensitivity == CaseSensitivity.All || caseSensitivity == CaseSensitivity.CaseSensitive)
                     {
-                        duration = benchmark.BenchMarkDelegate(compiledEngineCaseSensitive, benchmark.Formula);
+                        duration = benchmark.BenchMarkDelegate(compiledEngineCaseSensitive, benchmark.Formula, benchmark.VariableDict);
                         table.AddBenchmarkRecord("Compiled", true, benchmark.Formula, null, NumberOfTests, duration);
                     }
                 }
@@ -121,13 +123,21 @@ namespace Jace.Benchmark
             return table;
         }
 
-        private static TimeSpan BenchMarkCalculationEngine(CalculationEngine engine, string functionText)
+        private static TimeSpan BenchMarkCalculationEngine(CalculationEngine engine, string functionText, Dictionary<string, double> variableDict)
         {
             DateTime start = DateTime.Now;
 
             for (int i = 0; i < NumberOfTests; i++)
             {
-                engine.Calculate(functionText);
+                if (variableDict == null)
+                {
+                    engine.Calculate(functionText);
+                }
+                else
+                {
+                    engine.Calculate(functionText, new Dictionary<string, double>(variableDict));
+                }
+                
             }
 
             DateTime end = DateTime.Now;
@@ -135,7 +145,7 @@ namespace Jace.Benchmark
             return end - start;
         }
 
-        private static TimeSpan BenchMarkCalculationEngineFunctionBuild(CalculationEngine engine, string functionText)
+        private static TimeSpan BenchMarkCalculationEngineFunctionBuild(CalculationEngine engine, string functionText, Dictionary<string, double> variableDict)
         {
             DateTime start = DateTime.Now;
 

--- a/Jace.Tests/CalculationEngineTests.cs
+++ b/Jace.Tests/CalculationEngineTests.cs
@@ -107,6 +107,19 @@ namespace Jace.Tests
         }
 
         [TestMethod]
+        public void TestCalculateFormulaWithCaseSensitiveThrows()
+        {
+            Dictionary<string, double> variables = new Dictionary<string, double>();
+            variables.Add("var1", 1);
+            variables.Add("var2", 1);
+
+            CalculationEngine engine = new CalculationEngine(new JaceOptions { CaseSensitive = true });
+                //CultureInfo.InvariantCulture, ExecutionMode.Compiled, false, false, false);
+            var ex = AssertExtensions.ThrowsException<VariableNotDefinedException>( () => engine.Calculate("VaR1*vAr2", variables));
+            Assert.AreEqual("The variable \"VaR1\" used is not defined.", ex.Message);
+        }
+
+        [TestMethod]
         public void TestCalculateFormulaWithCaseSensitiveVariables1Interpreted()
         {
             Dictionary<string, double> variables = new Dictionary<string, double>();

--- a/Jace/CalculationEngine.cs
+++ b/Jace/CalculationEngine.cs
@@ -108,13 +108,13 @@ namespace Jace
         /// <param name="options">The <see cref="JaceOptions"/> to configure the behaviour of the engine.</param>
         public CalculationEngine(JaceOptions options)
         {
+            this.caseSensitive = options.CaseSensitive;
             this.executionFormulaCache = new MemoryCache<string, Func<IDictionary<string, double>, double>>(options.CacheMaximumSize, options.CacheReductionSize);
-            this.FunctionRegistry = new FunctionRegistry(false);
-            this.ConstantRegistry = new ConstantRegistry(false);
+            this.FunctionRegistry = new FunctionRegistry(caseSensitive);
+            this.ConstantRegistry = new ConstantRegistry(caseSensitive);
             this.cultureInfo = options.CultureInfo;
             this.cacheEnabled = options.CacheEnabled;
             this.optimizerEnabled = options.OptimizerEnabled;
-            this.caseSensitive = options.CaseSensitive;
 
             this.random = new Random();
 


### PR DESCRIPTION
Copy of original description by `aviita`:

When CaseSensitive is set to true from JaceOptions, performance should be significantly better than without case sensitivity. Case sensitivity setting was not passed to `FunctionRegistry` and `ConstantRegistry` constructors, which caused them to do extra lower case conversions in case variable dictionary was passed to the formula. Fixes [issue #75][1].

New benchmark was created to verify the fix. Benchmark needs to have variables which are provided to `CalculationEngine.Calculate()`, so VerifyVariableNames() gets called, which causes the extra calls to `ToLowerFast()`.

Below results show ~200 ms improvement when Case Sensitive is true. Results table was created by running benchmark separately with and without fix and copying results to one table.

| Engine     | Case Sensitive | Formula | Total Iteration | Total Duration (fix)   | Total Duration (no fix) |
|------------|----------------|---------|-----------------|------------------------|-------------------------|
| Interpreted |False |something2 - (var1 + var2 * 3)/(2+3) |1000000|00:00:01.6005267|00:00:01.5919016 |
| Interpreted |True  |something2 - (var1 + var2 * 3)/(2+3) |1000000|00:00:00.6069845|00:00:00.8390435 |
| Compiled    |False |something2 - (var1 + var2 * 3)/(2+3) |1000000|00:00:01.5865326|00:00:01.5770084 |
| Compiled    |True  |something2 - (var1 + var2 * 3)/(2+3) |1000000|00:00:00.5930012|00:00:00.8189981 |

Additionally:
- Unit test which tests case sensitivity enabled throws when variable case does not match
- Benchmark uses dictionary copy constructor to avoid throwing due to dictionary being modified with constants and then failing on `VerifyVariableNames()`.

[1]: https://github.com/pieterderycke/Jace/issues/75