### PR TITLE
Interpreter constants fix

### DIFF
--- a/Jace.Tests/CalculationEngineTests.cs
+++ b/Jace.Tests/CalculationEngineTests.cs
@@ -557,6 +557,32 @@ namespace Jace.Tests
         }
 
         [TestMethod]
+        public void TestConstantBuildCompiled()
+        {
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled);
+            Func<Dictionary<string, double>, double> formula = engine.Build("pi");
+
+            Dictionary<string, double> variables = new Dictionary<string, double>();
+
+            double result = formula(variables);
+
+            Assert.AreEqual(Math.PI, result);
+        }
+
+        [TestMethod]
+        public void TestConstantBuildInterpreted()
+        {
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted);
+            Func<Dictionary<string, double>, double> formula = engine.Build("pi");
+
+            Dictionary<string, double> variables = new Dictionary<string, double>();
+
+            double result = formula(variables);
+
+            Assert.AreEqual(Math.PI, result);
+        }
+
+        [TestMethod]
         public void TestVariableCaseFuncCompiled()
         {
             CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled);

--- a/Jace/Execution/Interpreter.cs
+++ b/Jace/Execution/Interpreter.cs
@@ -66,8 +66,11 @@ namespace Jace.Execution
 
                 if (variableFound)
                     return value;
-                else
-                    throw new VariableNotDefinedException(string.Format("The variable \"{0}\" used is not defined.", variable.Name));
+                
+                if (constantRegistry.IsConstantName(variable.Name))
+                    return constantRegistry.GetConstantInfo(variable.Name).Value;
+
+                throw new VariableNotDefinedException(string.Format("The variable \"{0}\" used is not defined.", variable.Name));
             }
             else if (operation.GetType() == typeof(Multiplication))
             {


### PR DESCRIPTION
A fix for the missing constants lookup in interpreter mode as proposed by @FabianNitsche in the [upstream repository](https://github.com/pieterderycke/Jace/pull/72).