### PR TITLE
Correctly handle invalid inputs in case of invalid scientific numbers

### DIFF
--- a/Jace.Tests/TokenReaderTests.cs
+++ b/Jace.Tests/TokenReaderTests.cs
@@ -574,5 +574,15 @@ namespace Jace.Tests
             Assert.AreEqual(7, tokens[2].StartPosition);
             Assert.AreEqual(6, tokens[2].Length);
         }
+
+        [TestMethod]
+        public void TestTokenReader37()
+        {
+            AssertExtensions.ThrowsException<ParseException>(() =>
+            {
+                TokenReader reader = new TokenReader(CultureInfo.InvariantCulture);
+                List<Token> tokens = reader.Read("3e");
+            });
+        }
     }
 }

--- a/Jace/Tokenizer/TokenReader.cs
+++ b/Jace/Tokenizer/TokenReader.cs
@@ -64,7 +64,7 @@ namespace Jace.Tokenizer
                         {
                             isScientific = IsScientificNotation(characters[i]);
 
-                            if (characters[i + 1] == '-')
+                            if (characters.Length > i + 1 && characters[i + 1] == '-')
                             {
                                 buffer.Append(characters[i++]);
                             }
@@ -95,7 +95,10 @@ namespace Jace.Tokenizer
                             // Verify if we have a unary minus, we use the token '_' for a unary minus in the AST builder
                             tokens.Add(new Token() { TokenType = TokenType.Operation, Value = '_', StartPosition = startPosition, Length = 1 });
                         }
-                        // Else we skip
+                        else
+                        {
+                            throw new ParseException(string.Format("Invalid floating point number: {0}", buffer.ToString()));
+                        }
                     }
 
                     if (i == characters.Length)


### PR DESCRIPTION
Fix for missing error handling in case of invalid scientific numbers as proposed by @FabianNitsche in the [upstream repository](https://github.com/pieterderycke/Jace/pull/69).