### PR TITLE
Fix for precedence issues with exponents

### DIFF
--- a/Jace.Tests/AstBuilderTests.cs
+++ b/Jace.Tests/AstBuilderTests.cs
@@ -278,7 +278,7 @@ namespace Jace.Tests
         }
 
         [TestMethod]
-        public void TestUnaryMinus()
+        public void TestUnaryMinus1()
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
@@ -303,6 +303,29 @@ namespace Jace.Tests
             Assert.AreEqual(new IntegerConstant(5), addition.Argument1);
             Assert.AreEqual(new IntegerConstant(42), addition.Argument2);
         }
+
+        [TestMethod]
+        public void TestUnaryMinus2()
+        {
+            IFunctionRegistry registry = new MockFunctionRegistry();
+
+            AstBuilder builder = new AstBuilder(registry, false);
+            Operation operation = builder.Build(new List<Token>() { 
+                new Token() { Value = '_', TokenType = TokenType.Operation },
+                new Token() { Value = '(', TokenType = TokenType.LeftBracket },
+                new Token() { Value = 1, TokenType = TokenType.Integer },
+                new Token() { Value = ')', TokenType = TokenType.RightBracket },
+                new Token() { Value = '^', TokenType = TokenType.Operation }, 
+                new Token() { Value = 2, TokenType = TokenType.Integer }, 
+            });
+
+            UnaryMinus unaryMinus = (UnaryMinus)operation;
+
+            Exponentiation exponentiation = (Exponentiation)unaryMinus.Argument;
+            Assert.AreEqual(new IntegerConstant(1), exponentiation.Base);
+            Assert.AreEqual(new IntegerConstant(2), exponentiation.Exponent);
+        }
+
 
         [TestMethod]
         public void TestBuildInvalidFormula1()

--- a/Jace.Tests/CalculationEngineTests.cs
+++ b/Jace.Tests/CalculationEngineTests.cs
@@ -310,6 +310,24 @@ namespace Jace.Tests
         }
 
         [TestMethod]
+        public void TestUnaryMinus6Compiled()
+        {
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false, true);
+            double result = engine.Calculate("-(1*2)^2");
+
+            Assert.AreEqual(-4.0, result);
+        }
+
+        [TestMethod]
+        public void TestUnaryMinus6Interpreted()
+        {
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, true, false, true);
+            double result = engine.Calculate("-(1*2)^2");
+
+            Assert.AreEqual(-4.0, result);
+        }
+
+        [TestMethod]
         public void TestBuild()
         {
             CalculationEngine engine = new CalculationEngine();

--- a/Jace.Tests/TokenReaderTests.cs
+++ b/Jace.Tests/TokenReaderTests.cs
@@ -574,5 +574,42 @@ namespace Jace.Tests
             Assert.AreEqual(7, tokens[2].StartPosition);
             Assert.AreEqual(6, tokens[2].Length);
         }
+
+        [TestMethod]
+        public void TestTokenReader27()
+        {
+            TokenReader reader = new TokenReader(CultureInfo.InvariantCulture);
+            List<Token> tokens = reader.Read("-(1)^2");
+
+            Assert.AreEqual(6, tokens.Count);
+
+            Assert.AreEqual('_', tokens[0].Value);
+            Assert.AreEqual(0, tokens[0].StartPosition);
+            Assert.AreEqual(1, tokens[0].Length);
+            Assert.AreEqual(TokenType.Operation, tokens[0].TokenType);
+
+            Assert.AreEqual('(', tokens[1].Value);
+            Assert.AreEqual(1, tokens[1].StartPosition);
+            Assert.AreEqual(1, tokens[1].Length);
+            Assert.AreEqual(TokenType.LeftBracket, tokens[1].TokenType);
+
+            Assert.AreEqual(1, tokens[2].Value);
+            Assert.AreEqual(2, tokens[2].StartPosition);
+            Assert.AreEqual(1, tokens[2].Length);
+
+            Assert.AreEqual(')', tokens[3].Value);
+            Assert.AreEqual(3, tokens[3].StartPosition);
+            Assert.AreEqual(1, tokens[3].Length);
+            Assert.AreEqual(TokenType.RightBracket, tokens[3].TokenType);
+
+            Assert.AreEqual('^', tokens[4].Value);
+            Assert.AreEqual(4, tokens[4].StartPosition);
+            Assert.AreEqual(1, tokens[4].Length);
+            Assert.AreEqual(TokenType.Operation, tokens[4].TokenType);
+
+            Assert.AreEqual(2, tokens[5].Value);
+            Assert.AreEqual(5, tokens[5].StartPosition);
+            Assert.AreEqual(1, tokens[5].Length);
+        }
     }
 }

--- a/Jace/AstBuilder.cs
+++ b/Jace/AstBuilder.cs
@@ -42,8 +42,8 @@ namespace Jace
             operationPrecedence.Add('*', 4);
             operationPrecedence.Add('/', 4);
             operationPrecedence.Add('%', 4);
-            operationPrecedence.Add('_', 6);
-            operationPrecedence.Add('^', 5);
+            operationPrecedence.Add('_', 5);
+            operationPrecedence.Add('^', 6);
         }
 
         public Operation Build(IList<Token> tokens)


### PR DESCRIPTION
Fixes an issue with the precedence with the powers of negative numbers as proposed by @FabianNitsche in the [upstream repository.](https://github.com/pieterderycke/Jace/pull/63).