### PR TITLE
Cross-Platform Benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 bin/
 obj/
 *.suo

--- a/Jace.Benchmark/Jace.Benchmark.csproj
+++ b/Jace.Benchmark/Jace.Benchmark.csproj
@@ -8,8 +8,7 @@
     <ProjectReference Include="..\Jace\Jace.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.6.0" />
-    <PackageReference Include="EPPlus" Version="4.5.3.2" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.1" />

--- a/Jace.Benchmark/Jace.Benchmark.csproj
+++ b/Jace.Benchmark/Jace.Benchmark.csproj
@@ -2,10 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net7.0-windows</TargetFramework>
     <OutputType>Exe</OutputType>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <UseWPF>true</UseWPF>
-    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Jace\Jace.csproj" />

--- a/Jace.Benchmark/Jace.Benchmark.csproj
+++ b/Jace.Benchmark/Jace.Benchmark.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/Jace.Benchmark/Options.cs
+++ b/Jace.Benchmark/Options.cs
@@ -1,9 +1,4 @@
 ﻿using CommandLine;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Jace.Benchmark
 {
@@ -15,8 +10,8 @@ namespace Jace.Benchmark
         [Option('m', "mode", HelpText = "Specify the benchmark to execute.")]
         public BenchmarkMode Mode { get; set; }
 
-
-        [Option('f', "file", HelpText = "The file to store the output results in.", Required = true)]
+        [Option('f', "file", HelpText = "If set, the result will be written to the specified path as CSV.")]
         public string FileName { get; set; }
+        
     }
 }

--- a/Jace.Benchmark/Program.cs
+++ b/Jace.Benchmark/Program.cs
@@ -102,7 +102,7 @@ namespace Jace.Benchmark
             table.Columns.Add("Case Sensitive");
             table.Columns.Add("Formula");
             table.Columns.Add("Iterations per Random Formula", typeof(int));
-            table.Columns.Add("Total Iteration", typeof(int));
+            table.Columns.Add("Total Iterations", typeof(int));
             table.Columns.Add("Total Duration");
 
             // run benchmark scenarios

--- a/Jace.Benchmark/ResultWriters/ConsoleResultWriter.cs
+++ b/Jace.Benchmark/ResultWriters/ConsoleResultWriter.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+
+namespace Jace.Benchmark.Properties.ResultWriters;
+
+public class ConsoleResultWriter : IResultWriter
+{
+    public void Write(DataTable resultTable)
+    {
+    var columnCount = resultTable.Columns.Count;
+
+    // Calculate column widths
+    var maxLengths = new int[columnCount];
+    for (var i = 0; i < columnCount; i++)
+    {
+        maxLengths[i] = Math.Max(resultTable.Columns[i].ColumnName.Length, resultTable.AsEnumerable().Max(row => row[i].ToString().Length));
+    }
+
+    // Line length is the sum of all column widths + two spaces and one separator for each column + 1 separator at the end
+    var totalLineLength = maxLengths.Sum() + columnCount * 3 + 1;
+
+    // Separator line
+    var separatorLine = new string('-', totalLineLength);
+
+    // Header
+    Console.WriteLine();
+    Console.WriteLine(separatorLine);
+    Console.WriteLine(GetFormattedRow(resultTable.Columns.Cast<DataColumn>().Select(col => col.ColumnName), maxLengths));
+    Console.WriteLine(separatorLine);
+
+    // Data
+    foreach (DataRow row in resultTable.Rows)
+    {
+        Console.WriteLine(GetFormattedRow(row.ItemArray, maxLengths));
+    }
+
+    Console.WriteLine(separatorLine);
+    Console.WriteLine();
+    }
+    
+private static string GetFormattedRow(IEnumerable<object> values, int[] maxLengths)
+{
+    var formattedValues = new List<string>();
+    for (var i = 0; i < maxLengths.Length; i++)
+    {
+        var formattedValue = values.ElementAt(i).ToString();
+
+        // If the value is numeric, pad left; otherwise, pad right
+        formattedValue = IsNumeric(formattedValue) ? formattedValue.PadLeft(maxLengths[i]) : formattedValue.PadRight(maxLengths[i]);
+
+        formattedValues.Add(formattedValue);
+    }
+    return "| " + string.Join(" | ", formattedValues) + " |";
+}
+
+private static bool IsNumeric(string value)
+{
+    return double.TryParse(value, out _);
+}
+
+}

--- a/Jace.Benchmark/ResultWriters/ConsoleResultWriter.cs
+++ b/Jace.Benchmark/ResultWriters/ConsoleResultWriter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Globalization;
 using System.Linq;
 
 namespace Jace.Benchmark.Properties.ResultWriters;
@@ -47,8 +48,16 @@ private static string GetFormattedRow(IEnumerable<object> values, int[] maxLengt
     {
         var formattedValue = values.ElementAt(i).ToString();
 
-        // If the value is numeric, pad left; otherwise, pad right
-        formattedValue = IsNumeric(formattedValue) ? formattedValue.PadLeft(maxLengths[i]) : formattedValue.PadRight(maxLengths[i]);
+        // If the value is numeric, format with decimal separator and pad left; otherwise, pad right
+        if (IsNumeric(formattedValue))
+        {
+            var numericValue = double.Parse(formattedValue, CultureInfo.InvariantCulture);
+            formattedValue = numericValue.ToString("N0", CultureInfo.CurrentCulture).PadLeft(maxLengths[i]);
+        }
+        else
+        {
+            formattedValue = formattedValue.PadRight(maxLengths[i]);
+        }
 
         formattedValues.Add(formattedValue);
     }

--- a/Jace.Benchmark/ResultWriters/CsvResultWriter.cs
+++ b/Jace.Benchmark/ResultWriters/CsvResultWriter.cs
@@ -1,0 +1,29 @@
+using System.Data;
+using System.IO;
+using System.Linq;
+
+namespace Jace.Benchmark.Properties.ResultWriters;
+
+public class CsvResultWriter : IResultWriter
+{
+    private readonly string fileName;
+    
+    public CsvResultWriter(string fileName)
+    {
+        this.fileName = fileName;
+    }
+    
+    public void Write(DataTable resultTable)
+    {
+            using var writer = new StreamWriter(fileName);
+
+            // Write header
+            writer.WriteLine(string.Join(";", resultTable.Columns.Cast<DataColumn>().Select(col => col.ColumnName)));
+
+            // Write data
+            foreach (DataRow row in resultTable.Rows)
+            {
+                writer.WriteLine(string.Join(";", row.ItemArray));
+            }
+    }
+}

--- a/Jace.Benchmark/ResultWriters/ResultWriter.cs
+++ b/Jace.Benchmark/ResultWriters/ResultWriter.cs
@@ -1,0 +1,12 @@
+using System.Data;
+
+namespace Jace.Benchmark.Properties.ResultWriters;
+
+public interface IResultWriter
+{
+    /// <summary>
+    /// Creates an implementation-specific output of the given data table.
+    /// </summary>
+    /// <param name="resultTable">A data table of arbitrary dimensions.</param>
+    public void Write(DataTable resultTable);
+}

--- a/Jace.Tests/JaceOptionsTest.cs
+++ b/Jace.Tests/JaceOptionsTest.cs
@@ -1,0 +1,31 @@
+using System.Globalization;
+using Jace.Execution;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Jace.Tests;
+
+[TestClass]
+public class JaceOptionsTest
+{
+    [TestMethod]
+    public void TestCopyConstructor()
+    {
+        // change all values from their default values.
+        var baseOptions = new JaceOptions
+        {
+            CultureInfo = CultureInfo.InvariantCulture,
+            ExecutionMode = ExecutionMode.Interpreted,
+            CacheEnabled = false,
+            OptimizerEnabled = false,
+            CaseSensitive = true,
+            DefaultFunctions = false,
+            DefaultConstants = false,
+            CacheMaximumSize = 0,
+            CacheReductionSize = 0
+        };
+
+        // values must match in copied object
+        var copiedOptions = new JaceOptions(baseOptions);
+        Assert.AreEqual(baseOptions, copiedOptions);
+    }
+}

--- a/Jace/JaceOptions.cs
+++ b/Jace/JaceOptions.cs
@@ -36,8 +36,9 @@ namespace Jace
             OptimizerEnabled = options.OptimizerEnabled;
             CaseSensitive = options.CaseSensitive;
             DefaultConstants = options.DefaultConstants;
-            CacheMaximumSize = DefaultCacheMaximumSize;
-            CacheReductionSize = DefaultCacheReductionSize;
+            DefaultFunctions = options.DefaultFunctions;
+            CacheMaximumSize = options.CacheMaximumSize;
+            CacheReductionSize = options.CacheReductionSize;
         }
 
         /// <summary>
@@ -99,5 +100,36 @@ namespace Jace
         /// Enable or disable the default constants.
         /// </summary>
         public bool DefaultConstants { get; set; }
+        
+        protected bool Equals(JaceOptions other)
+        {
+            return Equals(CultureInfo, other.CultureInfo) && ExecutionMode == other.ExecutionMode && CacheEnabled == other.CacheEnabled && CacheMaximumSize == other.CacheMaximumSize && CacheReductionSize == other.CacheReductionSize && OptimizerEnabled == other.OptimizerEnabled && CaseSensitive == other.CaseSensitive && DefaultFunctions == other.DefaultFunctions && DefaultConstants == other.DefaultConstants;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((JaceOptions)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (CultureInfo != null ? CultureInfo.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (int)ExecutionMode;
+                hashCode = (hashCode * 397) ^ CacheEnabled.GetHashCode();
+                hashCode = (hashCode * 397) ^ CacheMaximumSize;
+                hashCode = (hashCode * 397) ^ CacheReductionSize;
+                hashCode = (hashCode * 397) ^ OptimizerEnabled.GetHashCode();
+                hashCode = (hashCode * 397) ^ CaseSensitive.GetHashCode();
+                hashCode = (hashCode * 397) ^ DefaultFunctions.GetHashCode();
+                hashCode = (hashCode * 397) ^ DefaultConstants.GetHashCode();
+                return hashCode;
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Currently, the benchmark can only be executed on Windows machines. This pull request introduces a number of changes which make the benchmark also compatible with other operating systems (e.g. Linux and macOS):

* Change project configuration to cross-platform build
* Replace Excel output with console and CSV options and remove the (proprietary) EPPlus library used in the original code.

By default, the benchmark writes a nicely formatted table to the terminal when finished. Optionally, you can still use the -f flag to specify a file location for result output. This will now write a CSV-file (;-separated) instead of an Excel file.