### PR TITLE
Performance Improvements

### DIFF
--- a/Jace.Tests/OptimizerTests.cs
+++ b/Jace.Tests/OptimizerTests.cs
@@ -25,9 +25,9 @@ public class OptimizerTests
         AstBuilder astBuilder = new AstBuilder(functionRegistry, true);
         Operation operation = astBuilder.Build(tokens);
 
-        Function optimizedFuction = (Function)optimizer.Optimize(operation, functionRegistry, null);
+        Function optimizedFunction = (Function)optimizer.Optimize(operation, functionRegistry, null);
 
-        Assert.AreEqual(typeof(FloatingPointConstant), optimizedFuction.Arguments[1].GetType());
+        Assert.AreEqual(typeof(FloatingPointConstant), optimizedFunction.Arguments[1].GetType());
     }
 
     [TestMethod]
@@ -44,10 +44,10 @@ public class OptimizerTests
         AstBuilder astBuilder = new AstBuilder(functionRegistry, true);
         Operation operation = astBuilder.Build(tokens);
 
-        Operation optimizedFuction = optimizer.Optimize(operation, functionRegistry, null);
+        Operation optimizedFunction = optimizer.Optimize(operation, functionRegistry, null);
 
-        Assert.AreEqual(typeof(Function), optimizedFuction.GetType());
-        Assert.AreEqual(typeof(IntegerConstant), ((Function)optimizedFuction).Arguments[0].GetType());
+        Assert.AreEqual(typeof(Function), optimizedFunction.GetType());
+        Assert.AreEqual(typeof(IntegerConstant), ((Function)optimizedFunction).Arguments[0].GetType());
     }
 
     [TestMethod]

--- a/Jace/AstBuilder.cs
+++ b/Jace/AstBuilder.cs
@@ -12,7 +12,6 @@ namespace Jace
     {
         private readonly IFunctionRegistry functionRegistry;
         private readonly IConstantRegistry localConstantRegistry;
-        private readonly bool caseSensitive;
         private readonly Dictionary<char, int> operationPrecedence = new Dictionary<char, int>();
         private readonly Stack<Operation> resultStack = new Stack<Operation>();
         private readonly Stack<Token> operatorStack = new Stack<Token>();
@@ -22,7 +21,6 @@ namespace Jace
         {
             this.functionRegistry = functionRegistry ?? throw new ArgumentNullException(nameof(functionRegistry));
             this.localConstantRegistry = compiledConstants ?? new ConstantRegistry(caseSensitive);
-            this.caseSensitive = caseSensitive;
 
             operationPrecedence.Add('(', 0);
             operationPrecedence.Add('&', 1);
@@ -74,10 +72,6 @@ namespace Jace
                             }
                             else
                             {
-                                if (!caseSensitive)
-                                {
-                                    tokenValue = tokenValue.ToLowerFast();
-                                }
                                 resultStack.Push(new Variable(tokenValue));
                             }
                         }

--- a/Jace/Execution/ConstantRegistry.cs
+++ b/Jace/Execution/ConstantRegistry.cs
@@ -1,19 +1,18 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using Jace.Util;
 
 namespace Jace.Execution
 {
     public class ConstantRegistry : IConstantRegistry
     {
-        private readonly bool caseSensitive;
         private readonly Dictionary<string, ConstantInfo> constants;
 
         public ConstantRegistry(bool caseSensitive)
         {
-            this.caseSensitive = caseSensitive;
-            this.constants = new Dictionary<string, ConstantInfo>();
+            constants = caseSensitive
+                ? new Dictionary<string, ConstantInfo>()
+                : new Dictionary<string, ConstantInfo>(StringComparer.OrdinalIgnoreCase);
         }
 
         public IEnumerator<ConstantInfo> GetEnumerator()
@@ -31,7 +30,7 @@ namespace Jace.Execution
             if (string.IsNullOrEmpty(constantName))
                 throw new ArgumentNullException(nameof(constantName));
 
-            return constants.TryGetValue(ConvertConstantName(constantName), out var constantInfo) ? constantInfo : null;
+            return constants.TryGetValue(constantName, out var constantInfo) ? constantInfo : null;
         }
 
         public bool IsConstantName(string constantName)
@@ -39,7 +38,7 @@ namespace Jace.Execution
             if (string.IsNullOrEmpty(constantName))
                 throw new ArgumentNullException(nameof(constantName));
 
-            return constants.ContainsKey(ConvertConstantName(constantName));
+            return constants.ContainsKey(constantName);
         }
 
         public void RegisterConstant(string constantName, double value)
@@ -52,8 +51,6 @@ namespace Jace.Execution
             if(string.IsNullOrEmpty(constantName))
                 throw new ArgumentNullException(nameof(constantName));
 
-            constantName = ConvertConstantName(constantName);
-
             if (constants.ContainsKey(constantName) && !constants[constantName].IsOverWritable)
             {
                 throw new Exception($"The constant \"{constantName}\" cannot be overwritten.");
@@ -62,11 +59,6 @@ namespace Jace.Execution
             var constantInfo = new ConstantInfo(constantName, value, isOverWritable);
 
             constants[constantName] = constantInfo;
-        }
-
-        private string ConvertConstantName(string constantName)
-        {
-            return caseSensitive ? constantName : constantName.ToLowerFast();
         }
     }
 }

--- a/Jace/Optimizer.cs
+++ b/Jace/Optimizer.cs
@@ -58,6 +58,12 @@ namespace Jace
                 var exponentiation = (Exponentiation)operation;
                 exponentiation.Base = Optimize(exponentiation.Base, functionRegistry, constantRegistry);
                 exponentiation.Exponent = Optimize(exponentiation.Exponent, functionRegistry, constantRegistry);
+
+                if (exponentiation.Exponent.GetType() == typeof(FloatingPointConstant) &&
+                    ((FloatingPointConstant)exponentiation.Exponent).Value == 0.0)
+                {
+                    return new FloatingPointConstant(1.0);
+                }
             }
             else if(operation.GetType() == typeof(Function))
             {

--- a/Jace/Optimizer.cs
+++ b/Jace/Optimizer.cs
@@ -22,53 +22,51 @@ namespace Jace
                 double result = executor.Execute(operation, functionRegistry, constantRegistry);
                 return new FloatingPointConstant(result);
             }
-            else
+
+            if (operation.GetType() == typeof(Addition))
             {
-                if (operation.GetType() == typeof(Addition))
-                {
-                    var addition = (Addition)operation;
-                    addition.Argument1 = Optimize(addition.Argument1, functionRegistry, constantRegistry);
-                    addition.Argument2 = Optimize(addition.Argument2, functionRegistry, constantRegistry);
-                }
-                else if (operation.GetType() == typeof(Subtraction))
-                {
-                    var subtraction = (Subtraction)operation;
-                    subtraction.Argument1 = Optimize(subtraction.Argument1, functionRegistry, constantRegistry);
-                    subtraction.Argument2 = Optimize(subtraction.Argument2, functionRegistry, constantRegistry);
-                }
-                else if (operation.GetType() == typeof(Multiplication))
-                {
-                    var multiplication = (Multiplication)operation;
-                    multiplication.Argument1 = Optimize(multiplication.Argument1, functionRegistry, constantRegistry);
-                    multiplication.Argument2 = Optimize(multiplication.Argument2, functionRegistry, constantRegistry);
-
-                    if ((multiplication.Argument1.GetType() == typeof(FloatingPointConstant) && ((FloatingPointConstant)multiplication.Argument1).Value == 0.0)
-                        || (multiplication.Argument2.GetType() == typeof(FloatingPointConstant) && ((FloatingPointConstant)multiplication.Argument2).Value == 0.0))
-                    {
-                        return new FloatingPointConstant(0.0);
-                    }
-                }
-                else if (operation.GetType() == typeof(Division))
-                {
-                    var division = (Division)operation;
-                    division.Dividend = Optimize(division.Dividend, functionRegistry, constantRegistry);
-                    division.Divisor = Optimize(division.Divisor, functionRegistry, constantRegistry);
-                }
-                else if (operation.GetType() == typeof(Exponentiation))
-                {
-                    var exponentiation = (Exponentiation)operation;
-                    exponentiation.Base = Optimize(exponentiation.Base, functionRegistry, constantRegistry);
-                    exponentiation.Exponent = Optimize(exponentiation.Exponent, functionRegistry, constantRegistry);
-                }
-                else if(operation.GetType() == typeof(Function))
-                {
-                    var function = (Function)operation;
-                    IList<Operation> arguments = function.Arguments.Select(a => Optimize(a, functionRegistry, constantRegistry)).ToList();
-                    function.Arguments = arguments;
-                }
-
-                return operation;
+                var addition = (Addition)operation;
+                addition.Argument1 = Optimize(addition.Argument1, functionRegistry, constantRegistry);
+                addition.Argument2 = Optimize(addition.Argument2, functionRegistry, constantRegistry);
             }
+            else if (operation.GetType() == typeof(Subtraction))
+            {
+                var subtraction = (Subtraction)operation;
+                subtraction.Argument1 = Optimize(subtraction.Argument1, functionRegistry, constantRegistry);
+                subtraction.Argument2 = Optimize(subtraction.Argument2, functionRegistry, constantRegistry);
+            }
+            else if (operation.GetType() == typeof(Multiplication))
+            {
+                var multiplication = (Multiplication)operation;
+                multiplication.Argument1 = Optimize(multiplication.Argument1, functionRegistry, constantRegistry);
+                multiplication.Argument2 = Optimize(multiplication.Argument2, functionRegistry, constantRegistry);
+
+                if ((multiplication.Argument1.GetType() == typeof(FloatingPointConstant) && ((FloatingPointConstant)multiplication.Argument1).Value == 0.0)
+                    || (multiplication.Argument2.GetType() == typeof(FloatingPointConstant) && ((FloatingPointConstant)multiplication.Argument2).Value == 0.0))
+                {
+                    return new FloatingPointConstant(0.0);
+                }
+            }
+            else if (operation.GetType() == typeof(Division))
+            {
+                var division = (Division)operation;
+                division.Dividend = Optimize(division.Dividend, functionRegistry, constantRegistry);
+                division.Divisor = Optimize(division.Divisor, functionRegistry, constantRegistry);
+            }
+            else if (operation.GetType() == typeof(Exponentiation))
+            {
+                var exponentiation = (Exponentiation)operation;
+                exponentiation.Base = Optimize(exponentiation.Base, functionRegistry, constantRegistry);
+                exponentiation.Exponent = Optimize(exponentiation.Exponent, functionRegistry, constantRegistry);
+            }
+            else if(operation.GetType() == typeof(Function))
+            {
+                var function = (Function)operation;
+                IList<Operation> arguments = function.Arguments.Select(a => Optimize(a, functionRegistry, constantRegistry)).ToList();
+                function.Arguments = arguments;
+            }
+
+            return operation;
         }
     }
 }

--- a/Jace/Util/EngineUtil.cs
+++ b/Jace/Util/EngineUtil.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace Jace.Util
@@ -10,36 +11,7 @@ namespace Jace.Util
     {
         internal static IDictionary<string, double> ConvertVariableNamesToLowerCase(IDictionary<string, double> variables)
         {
-            var temp = new Dictionary<string, double>();
-            foreach (var keyValuePair in variables)
-            {
-                temp.Add(keyValuePair.Key.ToLowerFast(), keyValuePair.Value);
-            }
-
-            return temp;
-        }
-
-        // This is a fast ToLower for strings that are in ASCII
-        internal static string ToLowerFast(this string text)
-        {
-            var buffer = new StringBuilder(text.Length);
-            var modified = false;
-            for(var i = 0; i < text.Length; i++)
-            {
-                var c = text[i];
-
-                if (c >= 'A' && c <= 'Z')
-                {
-                    buffer.Append((char)(c + 32));
-                    modified = true;
-                }
-                else 
-                {
-                    buffer.Append(c);
-                }
-            }
-
-            return modified ? buffer.ToString() : text;
+            return new Dictionary<string, double>(variables, StringComparer.OrdinalIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
This pull request introduces two performance improvements:

* Replacing the "toLower" conversion for case-insensitive calculation with a case-insensitive string comparer. This is significantly faster and has the nice side effect of needing less code.
* Add handling for 0-exponents (x^0 -> 1) to the optimizer. It may not be as common as 0-multiplication, but that's no reason to waste calculation time on a complex base expression.